### PR TITLE
새로고침 시 SSR로 미리 생성된 UI가 보이는 문제 수정

### DIFF
--- a/src/app/_component/introduction/Introduction.css.ts
+++ b/src/app/_component/introduction/Introduction.css.ts
@@ -3,6 +3,7 @@ import { style } from '@vanilla-extract/css';
 import { mediaQueries } from '@/styles/mediaQueries.css.ts';
 
 export const introContainer = style({
+  visibility: 'hidden',
   display: 'grid',
   gridTemplateColumns: '1fr 1fr',
   alignItems: 'center',

--- a/src/app/_component/introduction/Introduction.tsx
+++ b/src/app/_component/introduction/Introduction.tsx
@@ -21,13 +21,15 @@ const Introduction = () => {
         type: 'wheel,touch,scroll',
         preventDefault: true,
       });
+      gsap.from(introContainer.current, {
+        autoAlpha: 0,
+      });
       gsap.from(`.${styles.introImageContainer} > :first-child`, {
         xPercent: -50,
         opacity: 0,
         duration: 1,
         ease: 'power2.In',
       });
-
       gsap.set(`.${styles.introImageContainer} > :nth-child(2)`, {
         visibility: 'hidden',
         position: 'absolute',
@@ -35,7 +37,6 @@ const Introduction = () => {
         left: 0,
         width: '100%',
       });
-
       gsap.from(`.${styles.introText}`, {
         xPercent: +30,
         opacity: 0,


### PR DESCRIPTION
#36 이슈에 대한 작업 내용입니다.

## 작업 내용

이 문제를 해결하기 위해 Loading 화면을 따로 추가하기와 **GSAP**의 `autoAlpha`를 사용하는 방법을 시도했고
추후 로딩 창을 추가할 수 있으나 해당 이슈에 대한 해결로는 후자가 맞다고 생각해 진행했습니다.

**Introduction 컴포넌트**의 최상위 부모 태그에 `visibility: hidden`을 적용하여 초기에는 화면이 보이지 않도록 설정했습니다. 이후 스크립트 로딩과 함께 `GSAP`로직이 실행되면서 `autoAlpha` 속성을 통해 `visibility`와 `opacity`를 조절하게 해서, 컴포넌트가 자연스럽게 보이도록 했습니다.

-> before

![refresh_issue](https://github.com/WonhyeongLee/lwh-membership-page/assets/54429762/1b4afa69-a9f7-49af-9e7b-195ab86dbda4)

-> after
![refresh_issue_fixed](https://github.com/WonhyeongLee/lwh-membership-page/assets/54429762/957543b3-deac-4a10-ab89-dfc96eb5f5e1)

